### PR TITLE
refactor(kafka配置): 关闭幂等性

### DIFF
--- a/internal/infrastructure/broker.go
+++ b/internal/infrastructure/broker.go
@@ -25,13 +25,13 @@ func loadKafkaConfig(conf *config.Kafka) *sarama.Config {
 	kafkaConfig.Producer.Flush.Frequency = 100 * time.Millisecond
 	kafkaConfig.Producer.Compression = sarama.CompressionGZIP
 	kafkaConfig.Producer.Partitioner = sarama.NewHashPartitioner
-	kafkaConfig.Producer.Idempotent = true
+	kafkaConfig.Producer.Idempotent = false
 	kafkaConfig.Metadata.AllowAutoTopicCreation = false
 	kafkaConfig.Consumer.Offsets.Initial = sarama.OffsetOldest
 	kafkaConfig.Consumer.Fetch.Max = conf.Consumer.Group.FetchMax
 	kafkaConfig.Consumer.Fetch.Min = conf.Consumer.Group.FetchMin
 	kafkaConfig.Consumer.Fetch.Default = 1024 * 1024
-	kafkaConfig.Net.MaxOpenRequests = 1
+	kafkaConfig.Net.MaxOpenRequests = 8
 	kafkaConfig.Consumer.Group.Session.Timeout = time.Second * time.Duration(conf.Consumer.Group.SessionTimeout)
 	kafkaConfig.Consumer.Group.Heartbeat.Interval = time.Duration(conf.Consumer.Group.HeartbeatInterval) * time.Second
 	return kafkaConfig

--- a/internal/infrastructure/persistence/gorm/order_inventory_event.go
+++ b/internal/infrastructure/persistence/gorm/order_inventory_event.go
@@ -15,7 +15,7 @@ type OrderInventoryEventRepositoryImpl struct {
 // FindEventExistsByOrderId 检查订单ID是否已经被处理过
 func (r *OrderInventoryEventRepositoryImpl) FindEventExistsByOrderId(ctx context.Context, orderId int64) (bool, error) {
 	eventExists := &model.OrderInventoryEvent{}
-	err := r.db.WithContext(ctx).Model(eventExists).Where("order_id = ?", orderId).Select("order_id").First(eventExists).Error
+	err := r.db.Model(eventExists).Where("order_id = ?", orderId).Select("order_id").First(eventExists).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return false, nil


### PR DESCRIPTION
由于业务逻辑能判断幂等性故可关闭幂等性提升吞吐量

fixed #65